### PR TITLE
fix: singlelineCommentsRE incorrect matching

### DIFF
--- a/src/regex.ts
+++ b/src/regex.ts
@@ -1,5 +1,5 @@
 const multilineCommentsRE = /\/\*.*?\*\//gms
-const singlelineCommentsRE = /\/\/.*$/gm
+const singlelineCommentsRE = /(?:^|\n|\r)\s*\/\/.*(?:\r|\n|$)/gm
 const templateLiteralRE = /\$\{(\s*(?:(?!\$\{).|\n|\r)*?\s*)\}/g
 const quotesRE = [
   /(["'`])((?:\\\1|(?!\1)|.|\r)*?)\1/gm,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -188,3 +188,21 @@ test('forgiving', () => {
   "
 `)
 })
+
+test('// in string', () => {
+  const str = [
+    'const url= `http://www.xx.com`;',
+    `const url1= 'http://www.xx.com';`,
+    'onMounted(() => console.log(123))',
+    'const str = `hello world`',
+    '// Notes'
+  ].join('\n')
+
+  expect(executeWithVerify(str)).toMatchInlineSnapshot(`
+    "const url= \`                 \`;
+    const url1= \'                 \';
+    onMounted(() => console.log(123))
+    const str = \`           \`
+            "
+  `)
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -192,10 +192,10 @@ test('forgiving', () => {
 test('// in string', () => {
   const str = [
     'const url= `http://www.xx.com`;',
-    `const url1= 'http://www.xx.com';`,
+    'const url1= \'http://www.xx.com\';',
     'onMounted(() => console.log(123))',
     'const str = `hello world`',
-    '// Notes'
+    '// Notes',
   ].join('\n')
 
   expect(executeWithVerify(str)).toMatchInlineSnapshot(`


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes nuxt/framework#123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

```
const url= `http://xxxxx`;

stripLiteralRegex(url) // `http:
```
result of stripLiteralRegex()  is  unreasonable

result should be `http://xxxxx`

I'm investigating [nuxt3](https://github.com/nuxt/nuxt.js/issues/14615) 

It was finally found that the reason was detectImports([unimport](https://github.com/unjs/unimport/blob/main/src/context.ts)) deal code error  

So locate here


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
