### PR TITLE
perf: avoid creating tokens list on `stripLiteral`

### DIFF
--- a/bench/index.bench.ts
+++ b/bench/index.bench.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { bench, describe } from 'vitest'
-import { stripLiteralJsTokens } from '../src'
+import { stripLiteral, stripLiteralDetailed } from '../src'
 
 const modules = {
   'vue-global': './node_modules/vue/dist/vue.runtime.global.js',
@@ -10,8 +10,15 @@ const modules = {
 Object.entries(modules).forEach(([name, path]) => {
   describe(`bench ${name}`, async () => {
     const code = await readFile(path, 'utf-8')
+    bench('stripLiteralDetailed (js-tokens)', () => {
+      stripLiteralDetailed(code)
+    }, {
+      warmupIterations: 1,
+    })
     bench('stripLiteral (js-tokens)', () => {
-      stripLiteralJsTokens(code)
+      stripLiteral(code)
+    }, {
+      warmupIterations: 1,
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,3 @@
-import type { StripLiteralOptions } from './types'
-import { stripLiteralJsTokens } from './js-tokens'
-
-export { stripLiteralJsTokens } from './js-tokens'
+// Reexports stripLiteralDetailed as stripLiteralJsTokens to maintain API backward compatibility
+export { stripLiteral, stripLiteralDetailed, stripLiteralDetailed as stripLiteralJsTokens } from './js-tokens'
 export * from './types'
-
-/**
- * Strip literal from code.
- */
-export function stripLiteral(code: string, options?: StripLiteralOptions) {
-  return stripLiteralDetailed(code, options).result
-}
-
-/**
- * Strip literal from code, return more detailed information.
- */
-export function stripLiteralDetailed(code: string, options?: StripLiteralOptions) {
-  return stripLiteralJsTokens(code, options)
-}

--- a/src/js-tokens.ts
+++ b/src/js-tokens.ts
@@ -2,88 +2,104 @@ import type { Token as JSToken } from 'js-tokens'
 import type { StripLiteralOptions } from './types'
 import jsTokens from 'js-tokens'
 
-export function stripLiteralJsTokens(code: string, options?: StripLiteralOptions) {
-  const FILL = options?.fillChar ?? ' '
-  const FILL_COMMENT = ' '
+const FILL_COMMENT = ' '
+
+function stripLiteralFromToken(token: JSToken, fillChar: NonNullable<StripLiteralOptions['fillChar']>, filter: NonNullable<StripLiteralOptions['filter']>): string {
+  if (token.type === 'SingleLineComment') {
+    return FILL_COMMENT.repeat(token.value.length)
+  }
+
+  if (token.type === 'MultiLineComment') {
+    return token.value.replace(/[^\n]/g, FILL_COMMENT)
+  }
+
+  if (token.type === 'StringLiteral') {
+    // js-token sees exotic vue prop value as an unclosed string literal
+    if (!token.closed) {
+      return token.value
+    }
+    const body = token.value.slice(1, -1)
+    if (filter(body)) {
+      return token.value[0] + fillChar.repeat(body.length) + token.value[token.value.length - 1]
+    }
+  }
+
+  if (token.type === 'NoSubstitutionTemplate') {
+    const body = token.value.slice(1, -1)
+    if (filter(body)) {
+      return `\`${body.replace(/[^\n]/g, fillChar)}\``
+    }
+  }
+
+  if (token.type === 'RegularExpressionLiteral') {
+    const body = token.value
+    if (filter(body)) {
+      return body.replace(/\/(.*)\/(\w?)$/g, (_, $1, $2) => `/${fillChar.repeat($1.length)}/${$2}`)
+    }
+  }
+
+  // `start${
+  if (token.type === 'TemplateHead') {
+    const body = token.value.slice(1, -2)
+    if (filter(body)) {
+      return `\`${body.replace(/[^\n]/g, fillChar)}\${`
+    }
+  }
+
+  // }end`
+  if (token.type === 'TemplateTail') {
+    const body = token.value.slice(0, -2)
+    if (filter(body)) {
+      return `}${body.replace(/[^\n]/g, fillChar)}\``
+    }
+  }
+
+  // }middle${
+  if (token.type === 'TemplateMiddle') {
+    const body = token.value.slice(1, -2)
+    if (filter(body)) {
+      return `}${body.replace(/[^\n]/g, fillChar)}\${`
+    }
+  }
+  return token.value
+}
+
+function optionsWithDefaults(options?: StripLiteralOptions) {
+  return {
+    fillChar: options?.fillChar ?? ' ',
+    filter: options?.filter ?? (() => true),
+  }
+}
+
+/**
+ * Strip literal from code.
+ */
+export function stripLiteral(code: string, options?: StripLiteralOptions) {
   let result = ''
 
-  const filter = options?.filter ?? (() => true)
+  const _options = optionsWithDefaults(options)
 
+  // jsx: false is more correct when parsing html
+  for (const token of jsTokens(code, { jsx: false })) {
+    result += stripLiteralFromToken(token, _options.fillChar, _options.filter)
+  }
+
+  return result
+}
+
+/**
+ * Strip literal from code, return more detailed information.
+ */
+export function stripLiteralDetailed(code: string, options?: StripLiteralOptions) {
+  let result = ''
   const tokens: JSToken[] = []
+  const _options = optionsWithDefaults(options)
 
   // jsx: false is more correct when parsing html
   for (const token of jsTokens(code, { jsx: false })) {
     tokens.push(token)
-
-    if (token.type === 'SingleLineComment') {
-      result += FILL_COMMENT.repeat(token.value.length)
-      continue
-    }
-
-    if (token.type === 'MultiLineComment') {
-      result += token.value.replace(/[^\n]/g, FILL_COMMENT)
-      continue
-    }
-
-    if (token.type === 'StringLiteral') {
-      // js-token sees exotic vue prop value as an unclosed string literal
-      if (!token.closed) {
-        result += token.value
-        continue
-      }
-      const body = token.value.slice(1, -1)
-      if (filter(body)) {
-        result += token.value[0] + FILL.repeat(body.length) + token.value[token.value.length - 1]
-        continue
-      }
-    }
-
-    if (token.type === 'NoSubstitutionTemplate') {
-      const body = token.value.slice(1, -1)
-      if (filter(body)) {
-        result += `\`${body.replace(/[^\n]/g, FILL)}\``
-        continue
-      }
-    }
-
-    if (token.type === 'RegularExpressionLiteral') {
-      const body = token.value
-      if (filter(body)) {
-        result += body.replace(/\/(.*)\/(\w?)$/g, (_, $1, $2) => `/${FILL.repeat($1.length)}/${$2}`)
-        continue
-      }
-    }
-
-    // `start${
-    if (token.type === 'TemplateHead') {
-      const body = token.value.slice(1, -2)
-      if (filter(body)) {
-        result += `\`${body.replace(/[^\n]/g, FILL)}\${`
-        continue
-      }
-    }
-
-    // }end`
-    if (token.type === 'TemplateTail') {
-      const body = token.value.slice(0, -2)
-      if (filter(body)) {
-        result += `}${body.replace(/[^\n]/g, FILL)}\``
-        continue
-      }
-    }
-
-    // }middle${
-    if (token.type === 'TemplateMiddle') {
-      const body = token.value.slice(1, -2)
-      if (filter(body)) {
-        result += `}${body.replace(/[^\n]/g, FILL)}\${`
-        continue
-      }
-    }
-
-    result += token.value
+    result += stripLiteralFromToken(token, _options.fillChar, _options.filter)
   }
-
   return {
     result,
     tokens,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,15 +1,13 @@
 import type { StripLiteralOptions } from '../src'
 import { expect } from 'vitest'
-import { stripLiteralDetailed } from '../src'
+import { stripLiteral } from '../src'
 
 export function executeWithVerify(code: string, options?: StripLiteralOptions) {
   code = code.trim()
-  const result = stripLiteralDetailed(code, options)
-
   // if (verifyAst && result.acorn.error)
   //   console.error(result.acorn.error)
 
-  const stripped = result.result
+  const stripped = stripLiteral(code, options)
 
   if (!options?.fillChar) {
     for (let i = 0; i < stripped.length; i++) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
When investigating an OOM error during build of a nuxt 3 app, I found that `stripLiteral` internally calls `stripLiteralDetailed` and returns only the result. This meant that the list of tokens was being generated but unused. 

This PR is a refactor to avoid creating the `tokens` array when `stripLiteral` is called. When bechmarking I've noticed anywhere between same speed to a **20% increase**. I do have to note that depending on warmup and run counts, these values do vary significantly. 

<img width="990" height="462" alt="image" src="https://github.com/user-attachments/assets/b25f0383-ca76-4d56-9eae-8943cfdc569f" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


### Additional context
I haven't been able to direclty measure the decreased memory usage of `stripLiteral` from the effect of this PR. I have tried capturing heap profiles and snapshots but can't really seem to capture the change. The best indicator I could come up with is observing the process' *Resident Set Size*.  For the small script below, this PR introduced an almost 2MB decrease (from 83.11MB to 81.14MB) on my machine.

<details>
<summary>Small memory test script</summary>

```
import { readFile } from 'fs/promises'
import {stripLiteral} from 'strip-literal'
import bytes from 'bytes'

const code = await readFile('./node_modules/vue/dist/vue.global.js', 'utf-8')

stripLiteral(code, undefined)
console.log(bytes(process.memoryUsage().rss))

```

</details>